### PR TITLE
Group permissions by subject

### DIFF
--- a/inst/tests/test.SystemMetadata.R
+++ b/inst/tests/test.SystemMetadata.R
@@ -138,3 +138,13 @@ test_that("SystemMetadata accessPolicy can be constructed and changed", {
     expect_that(as.character(sysmeta@accessPolicy$subject[[4]]), matches("baz"))    
 })
 
+test_that("access policy rules are nested by subject", {
+    sysmeta <- new("SystemMetadata",
+                   identifier = "test-nesting")
+    sysmeta <- addAccessRule(sysmeta, "someone", c("read", "write", "changePermission"))
+    doc <- XML::xmlParse(serializeSystemMetadata(sysmeta))
+    permissions <- XML::getNodeSet(doc, "//accessPolicy/allow/permission")
+    
+    expect_true(length(permissions) == 3)
+    expect_true(length(setdiff(c("read", "write", "changePermission"), XML::xmlValue(permissions))) == 0)
+})


### PR DESCRIPTION
Addresses https://github.com/ropensci/datapack/issues/53. I find unique subjects, adding an <allow> block for each, and for each subject, I find the unique set of their permissions and add <permission> blocks for each as sibling node to the respective <subject> element.

Edit: Spelling.
