### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
-
 language: R
-sudo: required
 cache: packages
-apt_packages:
-    - librdf0-dev
+addons:
+  apt:
+    packages:
+      - librdf0-dev


### PR DESCRIPTION
@mbjones you're too fast for me; looks like I need to do some troubleshooting of travis behavior, for some reason librdf0-dev dependencies break the `r-cran-httr` libraries (must be some curl dependency conflicts).  Let's see if this alternate config fixes that or not.  