### PR TITLE
Allow Setting File Location

### DIFF
--- a/R/Constants.R
+++ b/R/Constants.R
@@ -32,6 +32,7 @@ provWasGeneratedBy       <- sprintf("%s%s", provNS, "wasGeneratedBy")
 provAssociation          <- sprintf("%s%s", provNS, "Association")
 provWasAssociatedWith    <- sprintf("%s%s", provNS, "wasAssociatedWith")
 provAgent                <- sprintf("%s%s", provNS, "Agent")
+provAtLocation           <- sprintf("%s%s", provNS, "atLocation")
 provONE_NS               <- "http://purl.dataone.org/provone/2015/01/15/ontology#"
 provONEprogram           <- sprintf("%s%s", provONE_NS, "Program")
 provONEexecution         <- sprintf("%s%s", provONE_NS, "Execution")

--- a/R/DataObject.R
+++ b/R/DataObject.R
@@ -43,6 +43,7 @@
 #' @slot dataURL A character value for the URL used to load data into this DataObject
 #' @slot updated A hash containing logical values which indicate if system metadata or the data object have been updated since object creation.
 #' @slot oldId A character string containing the previous identifier used, before a \code{"replaceMember"} call.
+#' @slot relativeFilePath A character string holding the relative path of the data item
 #' @rdname DataObject-class
 #' @keywords classes
 #' @import methods
@@ -90,7 +91,8 @@ setClass("DataObject", slots = c(
     filename                = "character",
     dataURL                 = "character",
     updated                 = "hash",
-    oldId                   = "character")
+    oldId                   = "character",
+    relativeFilePath        = "character")
 )
 
 ##########################
@@ -122,16 +124,18 @@ setClass("DataObject", slots = c(
 #' @param mediaType The When specified, indicates the IANA Media Type (aka MIME-Type) of the object. The value should include the media type and subtype (e.g. text/csv).
 #' @param mediaTypeProperty A list, indicates IANA Media Type properties to be associated with the parameter \code{"mediaType"}
 #' @param dataURL A character string containing a URL to remote data (a repository) that this DataObject represents.
+#' @param relativeFilePath A string that denotes where the file should go if the package is downloaded
 #' @import digest
 #' @import uuid
 #' @examples
 #' data <- charToRaw("1,2,3\n4,5,6\n")
 #' do <- new("DataObject", "id1", dataobj=data, "text/csv", 
-#'   "uid=jones,DC=example,DC=com", "urn:node:KNB")
+#'   "uid=jones,DC=example,DC=com", "urn:node:KNB", filepath="data/rasters/data.tiff)
 #' @seealso \code{\link{DataObject-class}}
 setMethod("initialize", "DataObject", function(.Object, id=NA_character_, dataobj=NA, format=NA_character_, user=NA_character_, 
                                                mnNodeId=NA_character_, filename=NA_character_, seriesId=NA_character_,
-                                               mediaType=NA_character_, mediaTypeProperty=list(), dataURL=NA_character_) {
+                                               mediaType=NA_character_, mediaTypeProperty=list(), dataURL=NA_character_,
+                                               relativeFilePath=NA_character_) {
   
     # If no value has been passed in for 'id', then create a UUID for it.
     if (class(id) != "SystemMetadata" && is.na(id)) {
@@ -218,6 +222,7 @@ setMethod("initialize", "DataObject", function(.Object, id=NA_character_, dataob
     # downloaded from a data repository
     .Object@updated <- hash( keys=c("sysmeta", "data"), values=c(FALSE, FALSE))
     .Object@oldId <- NA_character_
+    .Object@relativeFilePath <- relativeFilePath
     return(.Object)
 })
 

--- a/R/DataPackage.R
+++ b/R/DataPackage.R
@@ -325,6 +325,10 @@ setMethod("addMember", signature("DataPackage"), function(x, do, mo=NA_character
             insertRelationship(x, getIdentifier(mo), getIdentifier(iObj))
         }
     }
+    # If the object's path was documented, add it to the resource map
+    if (!is.na(iObj@relativeFilePath)){
+        insertRelationship(x, getIdentifier(iObj), iObj@relativeFilePath, "http://www.w3.org/ns/prov#atLocation")
+    }
     return(x)
 })
 

--- a/inst/tests/test_DataObject.R
+++ b/inst/tests/test_DataObject.R
@@ -55,6 +55,15 @@ test_that("DataObject constructors work", {
     sha1_get_data <- digest(data2, algo="sha1", serialize=FALSE, file=FALSE)
     expect_match(sha1_get_data, sha1)
     unlink(tf)
+    
+    # Test that the constructor works for a data path, with a few different forms
+    relativeFilePath="./data/rasters/test.csv"
+    do <- new("DataObject", sm, data, filename="test.csv", relativeFilePath=relativeFilePath)
+    expect_that(do@relativeFilePath, equals(relativeFilePath))
+    
+    relativeFilePath="data/rasters/test.csv"
+    do <- new("DataObject", sm, data, filename="test.csv", relativeFilePath=relativeFilePath)
+    expect_that(do@relativeFilePath, equals(relativeFilePath))
 })
 test_that("DataObject accessPolicy methods", {
     library(datapack)

--- a/inst/tests/test_DataPackage.R
+++ b/inst/tests/test_DataPackage.R
@@ -391,10 +391,12 @@ test_that("BagIt serialization works", {
   
   user <- "smith"
   data <- charToRaw("1,2,3\n4,5,6")
+  doInFilePath = "myDir/textFile1.csv"
+  doOutFilePath = "myDir/textFile2.csv"
   node <- "urn:node:KNB"
   md1 <- new("DataObject", id=mdId, dataobj=charToRaw(someEML), format="eml://ecoinformatics.org/eml-2.1.1", user=user, mnNodeId=node)
-  doIn <- new("DataObject", id=doInId, dataobj=data, format="text/csv", user=user, mnNodeId=node)
-  doOut <- new("DataObject", id=doOutId, filename=csvfile, format="text/csv", user=user, mnNodeId=node)
+  doIn <- new("DataObject", id=doInId, dataobj=data, format="text/csv", user=user, mnNodeId=node, relativeFilePath=doInFilePath)
+  doOut <- new("DataObject", id=doOutId, filename=csvfile, format="text/csv", user=user, mnNodeId=node, relativeFilePath=doOutFilePath)
   dp <- addMember(dp, md1)
   dp <- addMember(dp, doIn)
   dp <- addMember(dp, doOut)
@@ -415,6 +417,9 @@ test_that("BagIt serialization works", {
  expect_true(file.exists(bagitFile))
  expect_true(file.info(bagitFile)[['size']] > 0)
 
+ zipFileNames = unzip(bagitFile, list=TRUE)$Name
+ expect_true(paste("data/",doInFilePath, sep="") %in% zipFileNames )
+ expect_true(paste("data/", doOutFilePath, sep="") %in% zipFileNames)
 }) 
 
 test_that("Adding provenance relationships to a DataPackage via describeWorkflow works", {

--- a/man/DataObject-class.Rd
+++ b/man/DataObject-class.Rd
@@ -39,6 +39,8 @@ contents of the data or file as a raw value (but this will read all of the data 
 \item{\code{updated}}{A hash containing logical values which indicate if system metadata or the data object have been updated since object creation.}
 
 \item{\code{oldId}}{A character string containing the previous identifier used, before a \code{"replaceMember"} call.}
+
+\item{\code{relativeFilePath}}{A character string holding the relative path of the data item}
 }}
 
 \section{Methods}{

--- a/man/DataObject-initialize.Rd
+++ b/man/DataObject-initialize.Rd
@@ -10,7 +10,8 @@
   dataobj = NA, format = NA_character_, user = NA_character_,
   mnNodeId = NA_character_, filename = NA_character_,
   seriesId = NA_character_, mediaType = NA_character_,
-  mediaTypeProperty = list(), dataURL = NA_character_)
+  mediaTypeProperty = list(), dataURL = NA_character_,
+  relativeFilePath = NA_character_)
 }
 \arguments{
 \item{.Object}{the DataObject instance to be initialized}
@@ -34,6 +35,8 @@
 \item{mediaTypeProperty}{A list, indicates IANA Media Type properties to be associated with the parameter \code{"mediaType"}}
 
 \item{dataURL}{A character string containing a URL to remote data (a repository) that this DataObject represents.}
+
+\item{relativeFilePath}{A string that denotes where the file should go when the package is downloaded.}
 }
 \description{
 When initializing a DataObject using passed in data, one can either pass 
@@ -52,8 +55,8 @@ downloaded from a repository.
 }
 \examples{
 data <- charToRaw("1,2,3\\n4,5,6\\n")
-do <- new("DataObject", "id1", dataobj=data, "text/csv", 
-  "uid=jones,DC=example,DC=com", "urn:node:KNB")
+do <- new("DataObject", "id1", dataobj=data, "text/csv",
+  "uid=jones,DC=example,DC=com", "urn:node:KNB", relativeFilePath="./miscData/rawData.txt")
 }
 \seealso{
 \code{\link{DataObject-class}}

--- a/vignettes/datapack-overview.Rmd
+++ b/vignettes/datapack-overview.Rmd
@@ -22,7 +22,7 @@ data repositories.
 ## Create a Single Object 
 The *datapack* DataObject class is a wrapper that contains both data and system metadata that describes the data. 
 The data can be either R `raw` data or a data file, for example a CSV file. The system metadata includes attributes such as the 
-object identifier, type, size, checksum, owner, version relationship to other objects, access rules, and other critical metadata. 
+object identifier, type, size, checksum, owner, version relationship to other objects, access rules, and other critical metadata. The DataObject class also holds additional metadata about the data file. For example, where the file should go when someone downlaodeds the package. This is often times the same as the filepath however, care should be taken to not include any drive letters or unnecessary folders.
 
 The following example shows how to create a DataObject from a CSV file:
 
@@ -31,7 +31,7 @@ library(datapack)
 library(uuid)
 csvfile <- system.file("extdata/sample-data.csv", package="datapack")
 myId <- paste("urn:uuid:", UUIDgenerate(), sep="")
-myObj <- new("DataObject", id=myId, format="text/csv", filename=csvfile)
+myObj <- new("DataObject", id=myId, format="text/csv", filename=csvfile, relativeFilePath="extdata/sample-data.csv")
 ```
 
 The DataObject `myObj` now contains the CSV data as well as the system-level 


### PR DESCRIPTION
This pull request is meant to satisfy issue #109.

~This is a draft pull request because the code has been written and unit tested however, I'm still testing it against DataONE and rdataone. I'd like to get early feedback on the changes I've made here to see if they're in the right direction. I'll slash out this disclaimer when I remove the tag.~

### Changes to DataObject
These changes can be found in the https://github.com/ropensci/datapack/commit/723b27ca2efa25fc62a9cf2232e83b95c8cd94d5 commit. I add a new slot, `relativeFilePath`, to the `DataObject` class and use it to hold the file path. Its default value is `NA_character_` which looks to be pretty standard. This member variable can be set like the others via the slot accessor.

Note that this value _only_ gets added to the resource map by the DataPackage class, because the resource map lives in that object. (See next section).

### Changes to DataPackage
The DataPackage change consist of two parts: Add the new information from DataObject to the resource map and parse the resource map when exporting as a bag.

#### Adding Paths to the Resource Map
The first change, c50c797, followed suite to add the new term to the global constants. This is used when inserting the relationship.

The heart of the second change (3202097) is a small addition to DataPackage. When a user adds a new DataObject to the DataPackage, a check is done to see whether the relativeFilePath was never not set (aka set). If so, then it adds the `provAtLocation` relation to the resource map.

```
    if (!is.na(iObj@relativeFilePath)){
        insertRelationship(x, getIdentifier(iObj), iObj@relativeFilePath, provAtLocation)
    }
```


#### Placing Files in Correct Download Location
There isn't _too_ much to this change other than the quick mental gymnastics below
```
    # Set the path to the file
    relFile <- paste(bagDir, "/data/", sep="")
    # If the user described the path of the file, use it
    if (!is.na(dataObj@relativeFilePath)) {
        relFile <- paste(relFile, dataObj@relativeFilePath, sep = "")
    } else if (!is.na(dataObj@filename)) {
        # Otherwise, if they specified a filename use that
        relFile <- paste(relFile, dataObj@filename, sep = "")
    } else {
        # If the filename wasn't specified, use the identifier
        relFile <- paste(relFile, getIdentifier(dataObj), sep="")
    }
```

I re-worked the way that the file name is set (`relFile`) by moving the logic to the top of the "Data file writing section". This occurs _after_ the resource map is written.

I made the decision to prioritize the `DataObject::relativeFilePath` over the `DataObject::filename`. If the user set the `relativeFilePath`, we use that since it has the relative path _and_ the filename. If the user didn't supply that, but gave the filename, that's used and the file ends up in the data/ directory. If neither are supplied, then the identifier is used as the filename and is also placed in the data/ directory.

The rest of the method just needed to be refactored because it was concatenating the bag path + `relFile` (which is I moved to the top), which only amounted to variable replacing.

## Testing

You can test this a number of ways...

1. Create a new DataObject with `relativeFilePath`. View the object and make sure that you see the record
2. Add it to a DataPackage and export it. You should have your data in the correct folder(s)
3. Create an EML document and upload it (use rdataone) along with the file from step 1. You should note that Metacat is fine with it.


